### PR TITLE
Add annotation to the template.

### DIFF
--- a/config/demo/20-attack-pod.yaml
+++ b/config/demo/20-attack-pod.yaml
@@ -16,14 +16,14 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: attack
-  annotations:
-    sidecar.istio.io/inject: "false"
 spec:
   replicas: 1
   template:
     metadata:
       labels:
         app: attack
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: attacker


### PR DESCRIPTION
The Istio webhook expects the annotation to skip adding sidecars to be under the deployment template's metadata