### PR TITLE
Flexvol driver no longer requires attach-detach flag setting in kubelet.

### DIFF
--- a/config/cluster/master-config.yaml
+++ b/config/cluster/master-config.yaml
@@ -133,7 +133,6 @@ coreos:
         --logtostderr=true \
         --register-node=true \
         --register-schedulable=false \
-        --enable-controller-attach-detach=false \
         --volume-plugin-dir=/opt/bin/volume-plugins
         Restart=always
         RestartSec=10

--- a/config/cluster/node-config.yaml
+++ b/config/cluster/node-config.yaml
@@ -59,7 +59,6 @@ coreos:
         --hostname-override=$private_ipv4 \
         --logtostderr=true \
         --network-plugin=cni \
-        --enable-controller-attach-detach=false \
         --volume-plugin-dir=/opt/bin/volume-plugins
         Restart=always
         RestartSec=10

--- a/config/install/05-calico.yaml
+++ b/config/install/05-calico.yaml
@@ -195,7 +195,7 @@ spec:
       terminationGracePeriodSeconds: 0
       initContainers:
       - name: flexvol-driver
-        image: quay.io/saurabh/flexvol:latest
+        image: quay.io/saurabh/flexvol:04242018
         imagePullPolicy: Always
         volumeMounts:
         - name: flexvol-driver-host


### PR DESCRIPTION
Fixed the issue in flex volume driver where it was not responding correctly to the init command of kubelet.

Verified the fix is working on a Vagrant cluster.