### PR TITLE
added instructions on configuring calicoctl for KDD

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,13 @@ You will need the latest (nightly) build of `calicoctl`.  Exit out of any pods y
 
     wget https://www.projectcalico.org/builds/calicoctl
     chmod +x calicoctl
-    
+
+In this demo, we are using the Kubernetes API server as our data store
+(KDD mode in Calico).  To ensure that calicoctl is using the
+correct data store, you need to do the following
+
+    export DATASTORE_TYPE=kubernetes KUBECONFIG=<your Kubectl config>
+	
 The policy uses alpha features of Calico behind a feature flag.  Enable these features.
 
     export ALPHA_FEATURES=serviceaccounts,httprules

--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ You will need the latest (nightly) build of `calicoctl`.  Exit out of any pods y
     wget https://www.projectcalico.org/builds/calicoctl
     chmod +x calicoctl
 
+Since we are using the Kubernetes API server as the Calico datastore in this demo
+(KDD mode), we need to configure calicoctl to use that datastore as well.  This can be done
+by setting the following environment variables
+
+    export CALICO_DATASTORE_TYPE=kubernetes CALICO_KUBECONFIG=<your kube config file>
+
 The policy uses alpha features of Calico behind a feature flag.  Enable these features.
 
     export ALPHA_FEATURES=serviceaccounts,httprules

--- a/README.md
+++ b/README.md
@@ -299,12 +299,6 @@ You will need the latest (nightly) build of `calicoctl`.  Exit out of any pods y
     wget https://www.projectcalico.org/builds/calicoctl
     chmod +x calicoctl
 
-In this demo, we are using the Kubernetes API server as our data store
-(KDD mode in Calico).  To ensure that calicoctl is using the
-correct data store, you need to do the following
-
-    export DATASTORE_TYPE=kubernetes KUBECONFIG=<your Kubectl config>
-	
 The policy uses alpha features of Calico behind a feature flag.  Enable these features.
 
     export ALPHA_FEATURES=serviceaccounts,httprules


### PR DESCRIPTION
I've added a bit of explanation and the appropriate environment variables to make sure that calicoctl is referencing the KDD store, rather than an etcd endpoint.  The docs for the demo aren't explicit as to what store is in use.

