### PR TITLE
Checkout go.mod and go.sum when populating the vendor diretory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,9 @@ vendor: go.mod go.sum
 	$(DOCKER_RUN) $(CALICO_BUILD) bash -c ' \
 	go mod download; \
 	go mod vendor; \
+	# We need to checkout go.mod and go.sum since the vendor command \
+	# can sometimes modify these files, causing a dirty tree. \
+	git checkout go.mod go.sum; \
 	mkdir -p vendor/github.com/envoyproxy; \
 	mkdir -p vendor/github.com/gogo; \
 	mkdir -p vendor/github.com/lyft; \


### PR DESCRIPTION
`go mod vendor` is annoying and modifies the `go.mod` file,
which causes `-dirty` builds, which in turn breaks our release process
which asserts that there are no local changes.

This is a quick-fix to get the v3.9 release unblocked.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```