### PR TITLE
support a new cpu architecture.

### DIFF
--- a/Dockerfile.mips64le
+++ b/Dockerfile.mips64le
@@ -1,0 +1,18 @@
+# Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM scratch
+
+ADD bin/dikastes-mips64le /dikastes
+ADD bin/healthz-mips64le /healthz
+CMD ["/dikastes"]

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ endif
 ifeq ($(BUILDARCH),x86_64)
 	BUILDARCH=amd64
 endif
+ifeq ($(BUILDARCH),mips64)
+	BUILDARCH=mips64le
+endif
 
 # unless otherwise set, I am building for my own architecture, i.e. not cross-compiling
 ARCH ?= $(BUILDARCH)
@@ -237,6 +240,7 @@ bin/dikastes-amd64: ARCH=amd64
 bin/dikastes-arm64: ARCH=arm64
 bin/dikastes-ppc64le: ARCH=ppc64le
 bin/dikastes-s390x: ARCH=s390x
+bin/dikastes-mips64le: ARCH=mips64le
 bin/dikastes-%: local_build proto $(SRC_FILES)
 	mkdir -p bin
 	$(DOCKER_RUN_RO) \
@@ -247,6 +251,7 @@ bin/healthz-amd64: ARCH=amd64
 bin/healthz-arm64: ARCH=arm64
 bin/healthz-ppc64le: ARCH=ppc64le
 bin/healthz-s390x: ARCH=s390x
+bin/healthz-mips64le: ARCH=mips64le
 bin/healthz-%: local_build proto $(SRC_FILES)
 	mkdir -p bin || true
 	-mkdir -p .go-pkg-cache $(GOMOD_CACHE) || true


### PR DESCRIPTION
## Description
I am going to submit mips64le architecture，The main reasons for adding support for mips64le architecture are:
1、The mips64le architecture is also the mainstream cpu architecture (amd64, arm64), which is used by many users;
2、Golang supports cross compilation, and mips64le is officially supported;
3、Is one of the container networks required by kubernetes.
Therefore, I hope that the release package also supports the mips64le architecture, which is convenient for more users.
Signed-off-by: houfangdong houfangdong@loongson.com

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
