### PR TITLE
Support to Envoy API v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,6 @@ bin/healthz-%: local_build proto $(SRC_FILES)
 # google/rpc (aka googleapis).
 PROTOC_IMPORTS =  -I proto\
 		  -I ./
-# Also remap the output modules to gogo versions of google/protobuf and google/rpc
-PROTOC_MAPPINGS = Menvoy/api/v2/core/address.proto=github.com/envoyproxy/data-plane-api/envoy/api/v2/core,Menvoy/api/v2/core/base.proto=github.com/envoyproxy/data-plane-api/envoy/api/v2/core,Menvoy/type/http_status.proto=github.com/envoyproxy/data-plane-api/envoy/type,Menvoy/type/percent.proto=github.com/envoyproxy/data-plane-api/envoy/type,Mgogoproto/gogo.proto=github.com/gogo/protobuf/gogoproto,Mgoogle/protobuf/any.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/struct.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/rpc/status.proto=github.com/gogo/googleapis/google/rpc,Menvoy/service/auth/v2/external_auth.proto=github.com/envoyproxy/data-plane-api/envoy/service/auth/v2
 
 proto: proto/felixbackend.pb.go proto/healthz.pb.go
 
@@ -151,14 +149,14 @@ proto/felixbackend.pb.go: proto/felixbackend.proto
 		      $(PROTOC_CONTAINER) \
 		      $(PROTOC_IMPORTS) \
 		      proto/*.proto \
-		      --gogofast_out=plugins=grpc,$(PROTOC_MAPPINGS):proto
+		      --gogofast_out=plugins=grpc:proto
 
 proto/healthz.pb.go: proto/healthz.proto
 	$(DOCKER_RUN) -v $(CURDIR):/src:rw \
 		      $(PROTOC_CONTAINER) \
 		      $(PROTOC_IMPORTS) \
 		      proto/*.proto \
-		      --gogofast_out=plugins=grpc,$(PROTOC_MAPPINGS):proto
+		      --gogofast_out=plugins=grpc:proto
 
 
 # Building the image

--- a/checker/check_test.go
+++ b/checker/check_test.go
@@ -17,7 +17,7 @@ package checker
 import (
 	"testing"
 
-	authz "github.com/envoyproxy/data-plane-api/envoy/service/auth/v2"
+	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/app-policy/policystore"

--- a/checker/match.go
+++ b/checker/match.go
@@ -23,8 +23,8 @@ import (
 
 	"fmt"
 
-	core "github.com/envoyproxy/data-plane-api/envoy/api/v2/core"
-	authz "github.com/envoyproxy/data-plane-api/envoy/service/auth/v2"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/checker/match_test.go
+++ b/checker/match_test.go
@@ -17,8 +17,8 @@ package checker
 import (
 	"testing"
 
-	core "github.com/envoyproxy/data-plane-api/envoy/api/v2/core"
-	auth "github.com/envoyproxy/data-plane-api/envoy/service/auth/v2"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/app-policy/policystore"
@@ -29,7 +29,7 @@ var (
 	socketAddressProtocolTCP = &core.Address{
 		Address: &core.Address_SocketAddress{
 			SocketAddress: &core.SocketAddress{
-				Protocol: core.TCP,
+				Protocol: core.SocketAddress_TCP,
 			},
 		},
 	}
@@ -37,7 +37,7 @@ var (
 	socketAddressProtocolUDP = &core.Address{
 		Address: &core.Address_SocketAddress{
 			SocketAddress: &core.SocketAddress{
-				Protocol: core.UDP,
+				Protocol: core.SocketAddress_UDP,
 			},
 		},
 	}
@@ -202,7 +202,7 @@ func TestMatchRule(t *testing.T) {
 			Address: &core.Address{Address: &core.Address_SocketAddress{
 				SocketAddress: &core.SocketAddress{
 					Address:       srcAddr,
-					Protocol:      core.TCP,
+					Protocol:      core.SocketAddress_TCP,
 					PortSpecifier: &core.SocketAddress_PortValue{PortValue: 8458},
 				}}},
 		},
@@ -211,7 +211,7 @@ func TestMatchRule(t *testing.T) {
 			Address: &core.Address{Address: &core.Address_SocketAddress{
 				SocketAddress: &core.SocketAddress{
 					Address:       dstAddr,
-					Protocol:      core.TCP,
+					Protocol:      core.SocketAddress_TCP,
 					PortSpecifier: &core.SocketAddress_PortValue{PortValue: 80},
 				}}},
 		},

--- a/checker/requestcache.go
+++ b/checker/requestcache.go
@@ -19,7 +19,7 @@ import (
 	"regexp"
 	"sync"
 
-	authz "github.com/envoyproxy/data-plane-api/envoy/service/auth/v2"
+	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/app-policy/policystore"

--- a/checker/requestcache_test.go
+++ b/checker/requestcache_test.go
@@ -3,7 +3,7 @@ package checker
 import (
 	"testing"
 
-	authz "github.com/envoyproxy/data-plane-api/envoy/service/auth/v2"
+	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	. "github.com/onsi/gomega"
 
 	"github.com/projectcalico/app-policy/policystore"

--- a/checker/server.go
+++ b/checker/server.go
@@ -17,10 +17,15 @@ package checker
 import (
 	"github.com/projectcalico/app-policy/policystore"
 
-	authz "github.com/envoyproxy/data-plane-api/envoy/service/auth/v2"
-	"github.com/gogo/googleapis/google/rpc"
+	core_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	authz_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	type_v2 "github.com/envoyproxy/go-control-plane/envoy/type"
+	_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	"google.golang.org/genproto/googleapis/rpc/status"
 )
 
 type authServer struct {
@@ -45,8 +50,8 @@ func (as *authServer) Check(ctx context.Context, req *authz.CheckRequest) (*auth
 		"Req.Source":      req.GetAttributes().GetSource(),
 		"Req.Destination": req.GetAttributes().GetDestination(),
 	}).Debug("Check start")
-	resp := authz.CheckResponse{Status: &rpc.Status{Code: INTERNAL}}
-	var st rpc.Status
+	resp := authz.CheckResponse{Status: &status.Status{Code: INTERNAL}}
+	var st status.Status
 
 	// Ensure that we only access as.Store once per Check call. The authServer can be updated to point to a different
 	// store asynchronously with this call, so we use a local variable to reference the PolicyStore for the duration of
@@ -60,14 +65,149 @@ func (as *authServer) Check(ctx context.Context, req *authz.CheckRequest) (*auth
 	store.Read(func(ps *policystore.PolicyStore) { st = checkStore(ps, req) })
 	resp.Status = &st
 	log.WithFields(log.Fields{
-		"Req.Method":      req.GetAttributes().GetRequest().GetHttp().GetMethod(),
-		"Req.Path":        req.GetAttributes().GetRequest().GetHttp().GetPath(),
-		"Req.Protocol":    req.GetAttributes().GetRequest().GetHttp().GetProtocol(),
-		"Req.Source":      req.GetAttributes().GetSource(),
-		"Req.Destination": req.GetAttributes().GetDestination(),
-		"Response":        resp,
+		"Req.Method":               req.GetAttributes().GetRequest().GetHttp().GetMethod(),
+		"Req.Path":                 req.GetAttributes().GetRequest().GetHttp().GetPath(),
+		"Req.Protocol":             req.GetAttributes().GetRequest().GetHttp().GetProtocol(),
+		"Req.Source":               req.GetAttributes().GetSource(),
+		"Req.Destination":          req.GetAttributes().GetDestination(),
+		"Response.Status":          resp.GetStatus(),
+		"Response.HttpResponse":    resp.GetHttpResponse(),
+		"Response.DynamicMetadata": resp.GetDynamicMetadata,
 	}).Debug("Check complete")
 	return &resp, nil
+}
+
+func (as *authServer) V2Compat() *authServerV2 {
+	return &authServerV2{
+		v3: as,
+	}
+}
+
+type authServerV2 struct {
+	v3 *authServer
+}
+
+// Check applies the currently loaded policy to a network request and renders a policy decision.
+func (as *authServerV2) Check(ctx context.Context, req *authz_v2.CheckRequest) (*authz_v2.CheckResponse, error) {
+	resp, err := as.v3.Check(ctx, checkRequestV3Compat(req))
+	if err != nil {
+		return nil, err
+	}
+	return checkResponseV2Compat(resp), nil
+}
+
+func checkRequestV3Compat(reqV2 *authz_v2.CheckRequest) *authz.CheckRequest {
+	return &authz.CheckRequest{
+		Attributes: &authz.AttributeContext{
+			Source:      peerV3Compat(reqV2.GetAttributes().GetSource()),
+			Destination: peerV3Compat(reqV2.GetAttributes().GetDestination()),
+			Request: &authz.AttributeContext_Request{
+				Time: reqV2.GetAttributes().GetRequest().GetTime(),
+				Http: &authz.AttributeContext_HttpRequest{
+					Id:       reqV2.GetAttributes().GetRequest().GetHttp().GetId(),
+					Method:   reqV2.GetAttributes().GetRequest().GetHttp().GetMethod(),
+					Headers:  reqV2.GetAttributes().GetRequest().GetHttp().GetHeaders(),
+					Path:     reqV2.GetAttributes().GetRequest().GetHttp().GetPath(),
+					Host:     reqV2.GetAttributes().GetRequest().GetHttp().GetHost(),
+					Scheme:   reqV2.GetAttributes().GetRequest().GetHttp().GetScheme(),
+					Query:    reqV2.GetAttributes().GetRequest().GetHttp().GetQuery(),
+					Fragment: reqV2.GetAttributes().GetRequest().GetHttp().GetFragment(),
+					Size:     reqV2.GetAttributes().GetRequest().GetHttp().GetSize(),
+					Protocol: reqV2.GetAttributes().GetRequest().GetHttp().GetProtocol(),
+					Body:     reqV2.GetAttributes().GetRequest().GetHttp().GetBody(),
+				},
+			},
+			ContextExtensions: reqV2.GetAttributes().GetContextExtensions(),
+			MetadataContext: &core.Metadata{
+				FilterMetadata: reqV2.GetAttributes().GetMetadataContext().GetFilterMetadata(),
+			},
+		},
+	}
+}
+
+func peerV3Compat(peerV2 *authz_v2.AttributeContext_Peer) *authz.AttributeContext_Peer {
+	peer := authz.AttributeContext_Peer{
+		Service:     peerV2.Service,
+		Labels:      peerV2.GetLabels(),
+		Principal:   peerV2.GetPrincipal(),
+		Certificate: peerV2.GetCertificate(),
+	}
+
+	switch addr := peerV2.GetAddress().GetAddress().(type) {
+	case *core_v2.Address_Pipe:
+		peer.Address = &core.Address{
+			Address: &core.Address_Pipe{
+				Pipe: &core.Pipe{
+					Path: addr.Pipe.GetPath(),
+					Mode: addr.Pipe.GetMode(),
+				},
+			},
+		}
+	case *core_v2.Address_SocketAddress:
+		socketAddress := core.SocketAddress{
+			Protocol:     core.SocketAddress_Protocol(addr.SocketAddress.GetProtocol()),
+			Address:      addr.SocketAddress.GetAddress(),
+			ResolverName: addr.SocketAddress.GetResolverName(),
+			Ipv4Compat:   addr.SocketAddress.GetIpv4Compat(),
+		}
+		switch port := addr.SocketAddress.GetPortSpecifier().(type) {
+		case *core_v2.SocketAddress_PortValue:
+			socketAddress.PortSpecifier = &core.SocketAddress_PortValue{
+				PortValue: port.PortValue,
+			}
+		case *core_v2.SocketAddress_NamedPort:
+			socketAddress.PortSpecifier = &core.SocketAddress_NamedPort{
+				NamedPort: port.NamedPort,
+			}
+		}
+		peer.Address = &core.Address{
+			Address: &core.Address_SocketAddress{
+				SocketAddress: &socketAddress,
+			},
+		}
+	}
+
+	return &peer
+}
+
+func checkResponseV2Compat(respV3 *authz.CheckResponse) *authz_v2.CheckResponse {
+	respV2 := authz_v2.CheckResponse{
+		Status: respV3.Status,
+	}
+	switch http3 := respV3.HttpResponse.(type) {
+	case *authz.CheckResponse_OkResponse:
+		respV2.HttpResponse = &authz_v2.CheckResponse_OkResponse{
+			OkResponse: &authz_v2.OkHttpResponse{
+				Headers: headersV2Compat(http3.OkResponse.GetHeaders()),
+			}}
+	case *authz.CheckResponse_DeniedResponse:
+		respV2.HttpResponse = &authz_v2.CheckResponse_DeniedResponse{
+			DeniedResponse: &authz_v2.DeniedHttpResponse{
+				Headers: headersV2Compat(http3.DeniedResponse.GetHeaders()),
+				Status:  httpStatusV2Compat(http3.DeniedResponse.GetStatus()),
+				Body:    http3.DeniedResponse.GetBody(),
+			}}
+	}
+	return &respV2
+}
+
+func headersV2Compat(hdrs []*core.HeaderValueOption) []*core_v2.HeaderValueOption {
+	hdrsV2 := make([]*core_v2.HeaderValueOption, len(hdrs))
+	for i, hv := range hdrs {
+		hdrsV2[i] = &core_v2.HeaderValueOption{
+			Header: &core_v2.HeaderValue{
+				Key:   hv.GetHeader().GetKey(),
+				Value: hv.GetHeader().GetValue(),
+			},
+		}
+	}
+	return hdrsV2
+}
+
+func httpStatusV2Compat(s *_type.HttpStatus) *type_v2.HttpStatus {
+	return &type_v2.HttpStatus{
+		Code: type_v2.StatusCode(s.Code),
+	}
 }
 
 // updateStores pulls PolicyStores off the channel and assigns them.

--- a/checker/server_test.go
+++ b/checker/server_test.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"testing"
 
-	authz "github.com/envoyproxy/data-plane-api/envoy/service/auth/v2"
-	"github.com/gogo/googleapis/google/rpc"
+	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	. "github.com/onsi/gomega"
+	"google.golang.org/genproto/googleapis/rpc/status"
 
 	"github.com/projectcalico/app-policy/policystore"
 	"github.com/projectcalico/app-policy/proto"
@@ -73,5 +73,5 @@ func TestCheckStore(t *testing.T) {
 		Expect(err).ToNot(HaveOccurred())
 		return rsp
 	}
-	Eventually(chk).Should(Equal(&authz.CheckResponse{Status: &rpc.Status{Code: OK}}))
+	Eventually(chk).Should(Equal(&authz.CheckResponse{Status: &status.Status{Code: OK}}))
 }

--- a/cmd/dikastes/dikastes.go
+++ b/cmd/dikastes/dikastes.go
@@ -30,8 +30,9 @@ import (
 	"github.com/projectcalico/app-policy/uds"
 
 	"github.com/docopt/docopt-go"
-	authz "github.com/envoyproxy/data-plane-api/envoy/service/auth/v2"
-	authzv2alpha "github.com/envoyproxy/data-plane-api/envoy/service/auth/v2alpha"
+	authz_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	authz_v2alpha "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2alpha"
+	authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
@@ -103,7 +104,9 @@ func runServer(arguments map[string]interface{}) {
 	stores := make(chan *policystore.PolicyStore)
 	checkServer := checker.NewServer(ctx, stores)
 	authz.RegisterAuthorizationServer(gs, checkServer)
-	authzv2alpha.RegisterAuthorizationServer(gs, checkServer)
+	checkServerV2 := checkServer.V2Compat()
+	authz_v2alpha.RegisterAuthorizationServer(gs, checkServerV2)
+	authz_v2.RegisterAuthorizationServer(gs, checkServerV2)
 
 	// Synchronize the policy store
 	opts := uds.GetDialOptions()

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ go 1.15
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
-	github.com/envoyproxy/data-plane-api v0.0.0-20210121155913-ffd420ef8a9a
-	github.com/gogo/googleapis v1.2.0
+	github.com/envoyproxy/go-control-plane v0.9.8
 	github.com/gogo/protobuf v1.3.2
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
@@ -13,6 +12,7 @@ require (
 	github.com/projectcalico/libcalico-go v1.7.2-0.20210428175515-8bf30375a54f
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/grpc v1.27.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa v0.0.1/go.mod h1:HNVadOiXCy7Jk3R2knJ+qm++zkncJxxBMpjdGgJ+UJc=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -75,7 +77,11 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633 h1:H2pdYOb3KQ1
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.8 h1:bbmjRkjmP0ZggMoahdNMmJFFnK7v5H+/j5niP5QH6bg=
+github.com/envoyproxy/go-control-plane v0.9.8/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.4.1 h1:7dLaJvASGRD7X49jSCSXXHwKPm0ZN9r9kJD+p+vS7dM=
 github.com/envoyproxy/protoc-gen-validate v0.4.1/go.mod h1:E+IEazqdaWv3FrnGtZIu3b9fPFMK8AzeTTrk9SfVwWs=
@@ -149,6 +155,7 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
@@ -339,6 +346,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -602,6 +610,7 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=

--- a/policystore/ipset.go
+++ b/policystore/ipset.go
@@ -22,7 +22,7 @@ import (
 
 	syncapi "github.com/projectcalico/app-policy/proto"
 
-	envoyapi "github.com/envoyproxy/data-plane-api/envoy/api/v2/core"
+	envoyapi "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/policystore/ipset_test.go
+++ b/policystore/ipset_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/projectcalico/app-policy/proto"
 
-	envoyapi "github.com/envoyproxy/data-plane-api/envoy/api/v2/core"
+	envoyapi "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
 func makeAddr(ip string, protocol envoyapi.SocketAddress_Protocol, port uint32) envoyapi.Address {
@@ -84,7 +84,7 @@ func TestAddIpAndPort(t *testing.T) {
 	RegisterTestingT(t)
 
 	uut := NewIPSet(proto.IPSetUpdate_IP_AND_PORT)
-	addr := makeAddr("2.2.2.2", envoyapi.TCP, 2222)
+	addr := makeAddr("2.2.2.2", envoyapi.SocketAddress_TCP, 2222)
 
 	uut.AddString("2.2.2.2,tcp:2222")
 	Expect(uut.ContainsAddress(&addr)).To(BeTrue())
@@ -102,7 +102,7 @@ func TestRemoveIpAndPort(t *testing.T) {
 	RegisterTestingT(t)
 
 	uut := NewIPSet(proto.IPSetUpdate_IP_AND_PORT)
-	addr := makeAddr("2.2.2.2", envoyapi.TCP, 2222)
+	addr := makeAddr("2.2.2.2", envoyapi.SocketAddress_TCP, 2222)
 
 	uut.RemoveString("2.2.2.2,tcp:2222")
 	Expect(uut.ContainsAddress(&addr)).To(BeFalse())
@@ -123,10 +123,10 @@ func TestIpPortContainsAddress(t *testing.T) {
 	RegisterTestingT(t)
 
 	uut := NewIPSet(proto.IPSetUpdate_IP_AND_PORT)
-	addrTCP := makeAddr("2.2.2.2", envoyapi.TCP, 2222)
-	addrUDP := makeAddr("2.2.2.2", envoyapi.UDP, 2222)
-	addrPort := makeAddr("2.2.2.2", envoyapi.TCP, 2223)
-	addrIp := makeAddr("2.2.2.3", envoyapi.TCP, 2222)
+	addrTCP := makeAddr("2.2.2.2", envoyapi.SocketAddress_TCP, 2222)
+	addrUDP := makeAddr("2.2.2.2", envoyapi.SocketAddress_UDP, 2222)
+	addrPort := makeAddr("2.2.2.2", envoyapi.SocketAddress_TCP, 2223)
+	addrIp := makeAddr("2.2.2.3", envoyapi.SocketAddress_TCP, 2222)
 
 	// Different protocol
 	uut.AddString("2.2.2.2,udp:2222")

--- a/syncher/syncserver_test.go
+++ b/syncher/syncserver_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/projectcalico/app-policy/proto"
 	"github.com/projectcalico/app-policy/uds"
 
-	envoyapi "github.com/envoyproxy/data-plane-api/envoy/api/v2/core"
+	envoyapi "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"google.golang.org/grpc"
 )
 
@@ -40,7 +40,7 @@ const addr3Ip = "2.2.2.2"
 var addr1 = &envoyapi.Address{
 	Address: &envoyapi.Address_SocketAddress{SocketAddress: &envoyapi.SocketAddress{
 		Address:  addr1Ip,
-		Protocol: envoyapi.TCP,
+		Protocol: envoyapi.SocketAddress_TCP,
 		PortSpecifier: &envoyapi.SocketAddress_PortValue{
 			PortValue: 5429,
 		},
@@ -49,7 +49,7 @@ var addr1 = &envoyapi.Address{
 var addr2 = &envoyapi.Address{
 	Address: &envoyapi.Address_SocketAddress{SocketAddress: &envoyapi.SocketAddress{
 		Address:  addr2Ip,
-		Protocol: envoyapi.TCP,
+		Protocol: envoyapi.SocketAddress_TCP,
 		PortSpecifier: &envoyapi.SocketAddress_PortValue{
 			PortValue: 6632,
 		},
@@ -58,7 +58,7 @@ var addr2 = &envoyapi.Address{
 var addr3 = &envoyapi.Address{
 	Address: &envoyapi.Address_SocketAddress{SocketAddress: &envoyapi.SocketAddress{
 		Address:  addr3Ip,
-		Protocol: envoyapi.TCP,
+		Protocol: envoyapi.SocketAddress_TCP,
 		PortSpecifier: &envoyapi.SocketAddress_PortValue{
 			PortValue: 2222,
 		},


### PR DESCRIPTION
## Description
This PR aim to upgrade Envoy API to v3. The v2 Envoy xDS API is deprecated in the 1.13.0 release (January 2020) and disabled-by-default in newer version. Envoy support for v2 xDS will be removed during Q1 2021. The deprecated v2/v2alpah API is still available by wrapping v3 gRPC server.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

<!--
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note
-->

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Adds support for the Envoy v3 API.
```
