### PR TITLE
Don't use commit-pin-updates, replace with trigger-auto-pin-update-process

### DIFF
--- a/.semaphore/update_pins.yml
+++ b/.semaphore/update_pins.yml
@@ -32,4 +32,5 @@ blocks:
       jobs:
         - name: 'Auto pin update'
           commands:
-            - CONFIRM=true GITHUB_TOKEN=${MARVIN_GITHUB_TOKEN} make commit-pin-updates
+            - CONFIRM=true make git-config
+            - CONFIRM=true GITHUB_TOKEN=${MARVIN_GITHUB_TOKEN} make trigger-auto-pin-update-process


### PR DESCRIPTION
commit-pin-updates is deprecated, we are no longer doing the pin updates and pushing them directly to master, we're updating them via a PR that will run the ci and get merged automatically

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
