### PR TITLE
dikastes: graceful shutdown of gRPC server should be used to exit cleanly after SIGTERM

### DIFF
--- a/cmd/dikastes/dikastes.go
+++ b/cmd/dikastes/dikastes.go
@@ -130,6 +130,7 @@ func runServer(arguments map[string]interface{}) {
 
 	// Block until a signal is received.
 	log.Infof("Got signal: %v", <-c)
+	gs.GracefulStop()
 }
 
 func runClient(arguments map[string]interface{}) {


### PR DESCRIPTION
## Description
Since I opened #276, I found a workaround which allows me to terminate dikastes sidecar on-demand when used as part of kubernetes job. I use shared process namespace in my pod and send SIGTERM to dikastes when needed.

This works as expected but the sidecar container usually ends with non-zero exit code because gRPC server shutdown is not handled properly.

Using the `GracefulStop()` library function resolves the issue for me and it generally seems to be the best practice anyway.